### PR TITLE
fix bullet3 submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bulletrs-sys/bullet3"]
 	path = bulletrs-sys/bullet3
-	url = http://github.com/not-fl3/bullet3
+	url = https://github.com/not-fl3/bullet3.git


### PR DESCRIPTION
For some reason, without the .git extension, I wasn't able to pull the submodule using a computer behind a proxy. You might have to run `git submodule sync` after changing this URL.